### PR TITLE
Fix OSX tab completion

### DIFF
--- a/lib/base/framework.py
+++ b/lib/base/framework.py
@@ -10,6 +10,16 @@ import os
 import cmd
 import subprocess
 
+# Enable OSX Tab Completion
+# http://stackoverflow.com/questions/7116038/python-tab-completion-mac-osx-10-7-lion
+
+import readline
+import rlcompleter
+if 'libedit' in readline.__doc__:
+    readline.parse_and_bind("bind ^I rl_complete")
+else:
+    readline.parse_and_bind("tab: complete")
+
 
 class Items(dict):
     """Core Options Items"""


### PR DESCRIPTION
https://github.com/open-security/vulnpwn/issues/16

```
vulnpwn [auto_completion] python vulnpwn

     ,           ,
    /             \
   ((__---,,,---__))
      (_) O O (_)_________
         \ _ /            |\
          o_o \  VULNPWN  | \
               \   _____  |  *
                |||   WW|||
                |||     |||



       =[ vulnpwn v1.00                      ]=
+ -- --=[ 0000 auxiliary                     ]=-- -- +
+ -- --=[ 0003 exploits                      ]=-- -- +
+ -- --=[ 0001 payloads                      ]=-- -- +
+ -- --=[ get more about security !          ]=-- -- +


vulnpwn > [tab] [tab]
debug edit  exit  help  load  set   shell show  unset use
vulnpwn > 

```