### PR TITLE
add Info command

### DIFF
--- a/lib/base/module.py
+++ b/lib/base/module.py
@@ -116,9 +116,10 @@ class Module(base.Base):
             for _ in authors:
                 self.output("  %s" % _)
 
-        self.output("")
-        self.output("Basic options:")
-        self.show_options()
+        if hasattr(self.options, 'keys') and self.options.keys():
+            self.output("")
+            self.output("Basic options:")
+            self.show_options()
 
         self.output("")
         self.output("Description:")

--- a/lib/base/module.py
+++ b/lib/base/module.py
@@ -100,6 +100,42 @@ class Module(base.Base):
 
         self.output('')
 
+    def do_info(self, *args, **kwargs):
+        """Displays information about one or more modules"""
+        self.output("")
+        self.output("%12s : %s" % ('Name', self.__info__.get('name')))
+        self.output("%12s : %s" % ('Module', self.__module__))
+        self.output("%12s : %s" % ('Licnese', self.__info__.get('license')))
+        self.output("%12s : %s" % ('Disclosed',
+                    self.__info__.get('disclosureDate')))
+        self.output("")
+
+        authors = self.__info__.get('author')
+        if len(authors) > 0:
+            self.output("Provided by:")
+            for _ in authors:
+                self.output("  %s" % _)
+
+        self.output("")
+        self.output("Basic options:")
+        self.show_options()
+
+        self.output("")
+        self.output("Description:")
+        desc = self.__info__.get('description')
+        desc_lines = desc.splitlines()
+        if len(desc_lines) > 0:
+            for _ in desc_lines:
+                self.output("  %s" % _.strip())
+
+        self.output("")
+        self.output("References:")
+        refers = self.__info__.get('references')
+        if len(refers) > 0:
+            for _ in refers:
+                self.output("  %s" % _)
+        self.output("")
+
     def do_run(self, *args, **kwargs):
         """run module main function"""
         self.main(*args, **kwargs)


### PR DESCRIPTION
issue https://github.com/open-security/vulnpwn/issues/31. 

Try to use **info** command to show current module information.

```
vulnpwn [info_command] ./vulnpwn

# cowsay++
 ___________
<  vulnpwn  >
 -----------
       \   ,__,
        \  (oo)____
           (__)    )\
              ||--|| *



       =[ vulnpwn v1.00                      ]=
+ -- --=[ get more about security !          ]=-- -- +


vulnpwn > use exploits/multi/http/apache_struts_dmi_rce
vulnpwn (exploits/multi/http/apache_struts_dmi_rce) > info
[*]
[*]         Name : Apache Struts S2_032 Remote Code Execution
[*]       Module : modules.exploits.multi.http.apache_struts_dmi_rce
[*]      Licnese : APACHE_LICENSE
[*]    Disclosed : Jun 01 2016
[*]
[*] Provided by:
[*]   Open-Security
[*]
[*] Basic options:
[*]
[*]     Name       Current Setting                           Description
[*]     ---------  ----------------------------------------  ---------------------
[*]     TARGETURI  /struts2-blank/example/HelloWorld.action  target uri to request
[*]     RHOST      172.16.176.226                            the target host
[*]     RPORT      8080                                      the target port
[*]
[*]
[*] Description:
[*]
[*]   This module exploits a remote command execution vulnerability in
[*]   Apache Struts version between 2.3.20 and 2.3.28
[*]   (except 2.3.20.2 and 2.3.24.2). Remote Code Execution can be
[*]   performed when using REST Plugin with ! operator when
[*]   Dynamic Method Invocation is enabled.
[*]
[*]
[*] References:
[*]   https://struts.apache.org/docs/s2-032.html
[*]
```

----

```
vulnpwn > use payloads/linux/x86/bin_sh
[!] Please set module 'options'
vulnpwn (payloads/linux/x86/bin_sh) > info
[*]
[*]         Name : Linux/x86 - execve /bin/sh shellcode
[*]       Module : modules.payloads.linux.x86.bin_sh
[*]      Licnese : APACHE_LICENSE
[*]    Disclosed : Jun 7 2015
[*]
[*] Provided by:
[*]   shell-storm
[*]
[*] Description:
[*]   Linux/x86 execve /bin/sh shellcode 23 bytes
[*]
[*] References:
[*]   http://shell-storm.org/shellcode/files/shellcode-827.php
[*]
```